### PR TITLE
Add option for weak verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,17 @@ signcode.sign(options, function (error) {
     console.log(options.path + ' is now signed')
   }
 })
+
+signcode.verify({ path: '/Users/kevin/apps/myapp.exe' }, function (error) {
+  if (error) {
+    console.error('Not signed', error.message)
+  } else {
+    console.log(options.path + ' is signed')
+  }
+})
 ```
 
-## Options
+### Signing Options
 
 | Name           | Type      | Required | Description                 |
 | :------------- | :-------- | :------- | :-------------------------- |
@@ -52,14 +60,22 @@ signcode.sign(options, function (error) {
 | `passwordPath` | `String`  | No       | Path to a file containing the password for the certificate or key. |
 | `site`         | `String`  | No       | Website URL to include in the signature. |
 
-## Command Line
+### Verification Options
+
+| Name           | Type      | Required | Description                 |
+| :------------- | :-------- | :------- | :-------------------------- |
+| `path`         | `String`  | Yes      | File path to executable to verify. |
+| `hash`         | `String`  | No       | Certificate fingerprint to expect on executable. |
+
+### Command Line Example
 
 ```sh
-signcode /Users/kevin/apps/myapp.exe \
+signcode sign /Users/kevin/apps/myapp.exe \
   --cert /Users/kevin/certs/cert.p12 \
   --prompt \
   --name 'My App' \
   --url 'http://birthday.pizza'
+signcode verify /Users/kevin/apps/myapp.exe
 ```
 
 Run `signcode -h` to see all the supported options.

--- a/cli.js
+++ b/cli.js
@@ -7,41 +7,44 @@ var yargs = require('yargs')
 
 var metadata = require('./package')
 
-var args = parseArgs()
-var fileToSign = args.argv._[0]
-if (!fileToSign) {
-  args.showHelp()
-  process.exit(1)
-}
-fileToSign = path.resolve(fileToSign)
+processCommand()
 
-var options = {
-  cert: path.resolve(args.argv.cert),
-  hash: ['sha1', 'sha256'],
-  key: args.argv.key ? path.resolve(args.argv.key) : args.argv.key,
-  name: args.argv.name,
-  overwrite: true,
-  password: args.argv.password,
-  path: fileToSign,
-  site: args.argv.url
-}
+function sign (argv) {
+  var options = {
+    cert: path.resolve(argv.cert),
+    hash: ['sha1', 'sha256'],
+    key: argv.key ? path.resolve(argv.key) : argv.key,
+    name: argv.name,
+    overwrite: true,
+    password: argv.password,
+    path: path.resolve(argv.file_to_sign),
+    site: argv.url
+  }
 
-if (args.argv.prompt) {
-  promptForPassword(function (password) {
-    options.password = password
-    sign(options)
-  })
-} else {
-  sign(options)
+  if (argv.prompt) {
+    promptForPassword(function (password) {
+      options.password = password
+      signcode.sign(options, exitIfError)
+    })
+  } else {
+    signcode.sign(options, exitIfError)
+  }
 }
 
-function sign (options) {
-  signcode.sign(options, function (error) {
-    if (error) {
-      console.error(error.message || error)
-      process.exit(1)
-    }
-  })
+function verify (argv) {
+  var options = {
+    path: path.resolve(argv.file_to_verify),
+    hash: argv.hash
+  }
+
+  signcode.verify(options, exitIfError)
+}
+
+function exitIfError (error) {
+  if (error) {
+    console.error(error.message || error)
+    process.exit(1)
+  }
 }
 
 function promptForPassword (callback) {
@@ -56,45 +59,53 @@ function promptForPassword (callback) {
   }
   prompt.start()
   prompt.get(promptConfig, function (error, result) {
-    if (error) {
-      console.error(error.message || error)
-      process.exit(1)
-    }
+    exitIfError(error)
     callback(result.password)
   })
 }
 
-function parseArgs () {
-  return yargs
-    .usage(metadata.name + ' file_to_sign [args]\n\nSign Windows executables from a Mac.\nVersion ' + metadata.version)
-    .option('cert', {
-      alias: 'c',
-      demand: true,
-      describe: 'Path to a .pem, .pfx, or .p12 certificate file',
-      type: 'string'
-    })
-    .option('key', {
-      alias: 'k',
-      describe: 'Path to .pem key file',
-      type: 'string'
-    })
-    .option('name', {
-      alias: 'n',
-      describe: 'Application name',
-      type: 'string'
-    })
-    .option('password', {
-      describe: 'Password to use for certificate/key pair',
-      type: 'string'
-    })
-    .option('prompt', {
-      describe: 'Prompt for a password',
-      type: 'boolean'
-    })
-    .option('url', {
-      alias: 'u',
-      describe: 'Application URL',
-      type: 'string'
-    })
+function processCommand () {
+  yargs
+    .usage(metadata.name + ' <command> path_to_executable [args]\n\nSign Windows executables from a Mac.\nVersion ' + metadata.version)
+    .command('sign <file_to_sign>', 'sign an executable', {
+      cert: {
+        alias: 'c',
+        demand: true,
+        describe: 'Path to a .pem, .pfx, or .p12 certificate file',
+        type: 'string'
+      },
+      key: {
+        alias: 'k',
+        describe: 'Path to .pem key file',
+        type: 'string'
+      },
+      name: {
+        alias: 'n',
+        describe: 'Application name',
+        type: 'string'
+      },
+      password: {
+        describe: 'Password to use for certificate/key pair',
+        type: 'string'
+      },
+      prompt: {
+        describe: 'Prompt for a password',
+        type: 'boolean'
+      },
+      url: {
+        alias: 'u',
+        describe: 'Application URL',
+        type: 'string'
+      }
+    }, sign)
+    .command('verify <file_to_verify> [args]', 'verify the signature on an executable', {
+      hash: {
+        alias: 'h',
+        describe: 'Certificate fingerprint to expect on executable',
+        type: 'string'
+      }
+    }, verify)
+    .demandCommand()
     .help('help')
+    .argv
 }

--- a/index.js
+++ b/index.js
@@ -134,10 +134,15 @@ function spawnVerify (options, callback) {
   var args = [
     'verify',
     '-in',
-    options.path,
-    '-require-leaf-hash',
-    options.hash
+    options.path
   ]
+
+  if (options.hash != null) {
+    args.push(
+      '-require-leaf-hash',
+      options.hash
+    )
+  }
 
   var signcode = ChildProcess.spawn(getSigncodePath(), args)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "prompt": "^1.0.0",
-    "yargs": "^4.6.0"
+    "yargs": "^7.0.2"
   }
 }

--- a/test/signcode-test.js
+++ b/test/signcode-test.js
@@ -214,6 +214,13 @@ describe('signcode', function () {
   })
 
   describe('.verify(options)', function () {
+    it('verifies the presence of a signature on the executable', function (done) {
+      var verifyOptions = {
+        path: path.join(__dirname, 'fixtures', 'electron-signed.exe')
+      }
+      signcode.verify(verifyOptions, done)
+    })
+
     it('verifies the sha1 signature on the executable', function (done) {
       var verifyOptions = {
         hash: 'sha1:9BF51511E06FA5FFE1CE408584B9981AA4EFE7EA',


### PR DESCRIPTION
This adds the option to pass only an assembly path to `signcode.verify` and skip the leaf hash check. This is useful if the only goal is to check for the presence of a signature.

Does that make sense? I was wondering about the status of `verify`; it is an export but not documented or available through the CLI. I could update this PR with documentation and a CLI option if desired.