### PR TITLE
Change to working timestamp server URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function spawnSign (options, callback) {
     '-out',
     outputPath,
     '-t',
-    'http://timestamp.verisign.com/scripts/timstamp.dll'
+    'http://timestamp.digicert.com/scripts/timstamp.dll'
   ]
 
   var certExtension = path.extname(options.cert)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signcode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Sign Windows executables from a Mac",
   "repository": "https://github.com/kevinsawicki/signcode",
   "main": "index.js",


### PR DESCRIPTION
The verisign timestamp server is no more. Details:
https://stackoverflow.com/a/65541787/1298835

The simplest solution is to change verisign → digicert. ( #12 )
An even better solution would be making it configurable. ( #11 )

Fixes #7 
Fixes #12 

You can use the PR in your project to make signcode usable again:

- yarn:
`yarn add kevinsawicki/signcode#13/head`

- npm:
`npm install kevinsawicki/signcode#pull/13/head`